### PR TITLE
Update the Release & Update Policy page for 3.2.x

### DIFF
--- a/src/AppBundle/Resources/views/About/release.html.twig
+++ b/src/AppBundle/Resources/views/About/release.html.twig
@@ -38,20 +38,20 @@
 	<h2>End of Maintenance</h2>
 	<p>End of Maintenance (EOM) occurs to a branch 18 months after its first stable (3.x.0) release. When this occurs we:</p>
 	<ul>
-		<li>Recommend you upgrade to the latest stable branch of phpBB</li>
-		<li>Only patch security issues in new maintenance releases</li>
-		<li>No longer allow new customisation [database] submissions except for updates to existing contributions</li>
+		<li>Recommend you upgrade to the latest stable branch of phpBB.</li>
+		<li>Only patch security issues in new maintenance releases.</li>
+		<li>No longer accept new contributions <em>(styles/extensions/etc)</em> for this branch in the customisation database, updates to existing contributions are still accepted.</li>
 	</ul>
 
 	<h2>End of Life</h2>
 	<p>End of Life (EOL) occurs to a branch 24 months after its first stable (3.x.0) release. When this occurs we:</p>
 	<ul>
-		<li>Strongly recommend you upgrade your version of phpBB to the latest stable release</li>
-		<li>No longer patch security issues</li>
-		<li>No longer make any releases of this branch</li>
-		<li>No longer allow contributions or updates for contributions to be submitted to our customisation database</li>
-		<li>Begin actively purging documentation for this branch of phpBB</li>
-		<li>Continue to provide support past EOL, with at least six months notice prior to dropping support</li>
+		<li>Strongly recommend you upgrade your version of phpBB to the latest stable release.</li>
+		<li>No longer patch security issues.</li>
+		<li>No longer make any releases of this branch.</li>
+		<li>No longer accept new or updated contributions <em>(styles/extensions/etc)</em> for this branch in the customisation database.</li>
+		<li>Begin actively purging documentation for this branch of phpBB.</li>
+		<li>Continue to provide support past EOL, with at least six months notice prior to dropping support.</li>
 	</ul>
 
 	<h2>Planned Release Timetable</h2>

--- a/src/AppBundle/Resources/views/About/release.html.twig
+++ b/src/AppBundle/Resources/views/About/release.html.twig
@@ -29,7 +29,7 @@
 		</div>
 		<div class="column column-thirds">
 			<strong>Development branch</strong>
-			<a class="big-tag double-height orange" href="{{ dev_github_phpbb_master }}">3.3.x</a>
+			<a class="big-tag double-height orange" href="{{ dev_github_phpbb_master }}">3.3.x (Proteus)</a>
 		</div>
 	</div>
 

--- a/src/AppBundle/Resources/views/About/release.html.twig
+++ b/src/AppBundle/Resources/views/About/release.html.twig
@@ -76,9 +76,9 @@
 					</tr>
 					<tr class="bg1">
 						<td><span class="mini-tag orange">3.2.x</span><span class="status-tag safe">OK</span></td>
-						<td>Planned: July 2016</td>
-						<td>Planned: December 2017</td>
-						<td>Planned: June 2018</td>
+						<td>July 2016</td>
+						<td>December 2017</td>
+						<td>June 2018</td>
 					</tr>
 					<tr class="bg2">
 						<td><span class="mini-tag blue">3.1.x</span><span class="status-tag safe">OK</span></td>

--- a/src/AppBundle/Resources/views/About/release.html.twig
+++ b/src/AppBundle/Resources/views/About/release.html.twig
@@ -20,23 +20,23 @@
 	<div class="columns release-versions">
 		<div class="column column-thirds">
 			<strong>Latest branch of phpBB</strong>
-			<a class="big-tag double-height blue" href="{{ downloads_path_31x }}">3.1.x (Ascraeus)</a>
+			<a class="big-tag double-height blue" href="{{ downloads_path_32x }}">3.2.x (Rhea)</a>
 		</div>
 		<div class="column column-thirds">
 			<strong>Branches in 'Maintenance'</strong>
-			<a class="big-tag blue" href="{{ downloads_path_31x }}">3.1.x (Ascraeus)</a>
-			<a class="big-tag dirty-green" href="{{ downloads_path_30x }}">3.0.x (Olympus)</a>
+			<a class="big-tag blue" href="{{ downloads_path_32x }}">3.2.x (Rhea)</a>
+			<a class="big-tag  dirty-green" href="{{ downloads_path_31x }}">3.1.x (Ascraeus)</a>
 		</div>
 		<div class="column column-thirds">
 			<strong>Development branch</strong>
-			<a class="big-tag double-height orange" href="{{ downloads_path_32x }}">3.2.x (Rhea)</a>
+			<a class="big-tag double-height orange" href="{{ dev_github_phpbb_master }}">3.3.x</a>
 		</div>
 	</div>
 
-	<p>phpBB releases are time-based meaning we release a new minor (x.y) or major (x) update once every year around November/December. In between minor releases we release maintenance releases (x.y.z) which include bug and, when required, security fixes. On occasion we also release patch level releases (x.y.z-PLn) which fix important issues introduced in a maintenance release.</p>
+	<p>phpBB releases are time-based meaning we plan to release a new minor (x.y) or major (x) update once every year around November/December. In between minor releases we release maintenance releases (x.y.z) which include bug and, when required, security fixes. On occasion we also release patch level releases (x.y.z-PLn) which fix important issues introduced in a maintenance release.</p>
 
 	<h2>End of Maintenance</h2>
-	<p>End of Maintenance (EOM) occurs to a branch 18 months after its first stable (3.x.0) release. This occurs in May each year. When this occurs we:</p>
+	<p>End of Maintenance (EOM) occurs to a branch 18 months after its first stable (3.x.0) release. When this occurs we:</p>
 	<ul>
 		<li>Recommend you upgrade to the latest stable branch of phpBB</li>
 		<li>Only patch security issues in new maintenance releases</li>
@@ -44,7 +44,7 @@
 	</ul>
 
 	<h2>End of Life</h2>
-	<p>End of Life (EOL) occurs to a branch 24 months after its first stable (3.x.0) release. This occurs in November each year. When this occurs we:</p>
+	<p>End of Life (EOL) occurs to a branch 24 months after its first stable (3.x.0) release. When this occurs we:</p>
 	<ul>
 		<li>Strongly recommend you upgrade your version of phpBB to the latest stable release</li>
 		<li>No longer patch security issues</li>
@@ -54,10 +54,7 @@
 		<li>Continue to provide support past EOL, with at least six months notice prior to dropping support</li>
 	</ul>
 
-	<h2>phpBB 3.0.x (Olympus)</h2>
-	<p>phpBB 3.0.x is a special case due to the length of its time in 'maintenance period'. It will reach its 'End of Maintenance' period in May 2015 and its 'End of Life' period will occur in November 2015.<br /><br />When phpBB 3.0 has reached EOM the above will apply and new modificiations (MODs) will no longer be accepted for submission into the customisation database whilst updates to existing MODs will be allowed. No new topics will be allowed in the MOD Reqeusts or MODs in Development forums. When 3.0 has reached EOL no new MOD updates will be permitted, they will be hidden from Titania (although downloadable still through the MOD Releases Forum) and the MOD 3.0 forums will be locked.</p>
-
-	<h2>Upcoming Timetable</h2>
+	<h2>Planned Release Timetable</h2>
 	<div class="forumbg forumbg-table">
 		<div class="inner">
 			<table class="table1 show-header responsive">{# TODO: show-header and responsive classes are usually added automatically by prosilver, but not in this case apparently #}
@@ -72,22 +69,28 @@
 				{# status CSS classes: status-tag + (safe | unsafe | dangerous | unreleased) #}
 				<tbody>
 					<tr class="bg1">
-						<td><span class="mini-tag dirty-green">3.0</span><span class="status-tag dangerous">EOL</span></td>
-						<td>December 2007</td>
-						<td>May 2015</td>
-						<td>November 2015</td>
+						<td><span class="mini-tag purple">3.3.x</span><span class="status-tag unreleased">DEV</span></td>
+						<td>November 2017</td>
+						<td>May 2019</td>
+						<td>November 2019</td>
+					</tr>
+					<tr class="bg1">
+						<td><span class="mini-tag orange">3.2.x</span><span class="status-tag safe">OK</span></td>
+						<td>Planned: July 2016</td>
+						<td>Planned: December 2017</td>
+						<td>Planned: June 2018</td>
 					</tr>
 					<tr class="bg2">
-						<td><span class="mini-tag blue">3.1</span><span class="status-tag safe">OK</span></td>
+						<td><span class="mini-tag blue">3.1.x</span><span class="status-tag safe">OK</span></td>
 						<td>November 2014</td>
 						<td>December 2016</td>
 						<td>June 2017</td>
 					</tr>
 					<tr class="bg1">
-						<td><span class="mini-tag orange">3.2</span><span class="status-tag unreleased">DEV</span></td>
-						<td>Planned: July 2016</td>
-						<td>Planned: December 2017</td>
-						<td>Planned: June 2018</td>
+						<td><span class="mini-tag dirty-green">3.0.x</span><span class="status-tag dangerous">EOL</span></td>
+						<td>December 2007</td>
+						<td>May 2015</td>
+						<td>November 2015</td>
 					</tr>
 				</tbody>
 			</table>
@@ -96,7 +99,7 @@
 
 	<h2>Contributing</h2>
 	<p>If you want to contribute a bug fix and it affects all maintained branches it will go into the next maintenance release of the lowest supported branch. Therefore it will likely go into the next 3.1.x release. (<span class="github-link"> <a href="{{ dev_github_phpbb_31x }}">3.1.x</a></span>).<br /><br />
-		If you want to contribute a new feature it will go into the 3.2.x development branch (<span class="github-link"> <a href="{{ dev_github_phpbb_32x }}">master</a></span>).</p>
+		If you want to contribute a new feature it will go into the master development branch (<span class="github-link"> <a href="{{ dev_github_phpbb_master }}">master</a></span>).</p>
 </div>
 
 </div>

--- a/src/AppBundle/Resources/views/About/release.html.twig
+++ b/src/AppBundle/Resources/views/About/release.html.twig
@@ -25,7 +25,7 @@
 		<div class="column column-thirds">
 			<strong>Branches in 'Maintenance'</strong>
 			<a class="big-tag blue" href="{{ downloads_path_32x }}">3.2.x (Rhea)</a>
-			<a class="big-tag  dirty-green" href="{{ downloads_path_31x }}">3.1.x (Ascraeus)</a>
+			<a class="big-tag dirty-green" href="{{ downloads_path_31x }}">3.1.x (Ascraeus)</a>
 		</div>
 		<div class="column column-thirds">
 			<strong>Development branch</strong>

--- a/src/AppBundle/Resources/views/About/release.html.twig
+++ b/src/AppBundle/Resources/views/About/release.html.twig
@@ -70,21 +70,21 @@
 				<tbody>
 					<tr class="bg1">
 						<td><span class="mini-tag purple">3.3.x</span><span class="status-tag unreleased">DEV</span></td>
-						<td>November 2017</td>
-						<td>May 2019</td>
-						<td>November 2019</td>
+						<td>December 2017</td>
+						<td>June 2019</td>
+						<td>December 2019</td>
 					</tr>
 					<tr class="bg1">
 						<td><span class="mini-tag orange">3.2.x</span><span class="status-tag safe">OK</span></td>
-						<td>July 2016</td>
-						<td>December 2017</td>
+						<td>January 2017</td>
 						<td>June 2018</td>
+						<td>December 2018</td>
 					</tr>
 					<tr class="bg2">
 						<td><span class="mini-tag blue">3.1.x</span><span class="status-tag safe">OK</span></td>
 						<td>November 2014</td>
-						<td>December 2016</td>
 						<td>June 2017</td>
+						<td>December 2017</td>
 					</tr>
 					<tr class="bg1">
 						<td><span class="mini-tag dirty-green">3.0.x</span><span class="status-tag dangerous">EOL</span></td>

--- a/src/AppBundle/Twig/GlobalsExtension.php
+++ b/src/AppBundle/Twig/GlobalsExtension.php
@@ -71,7 +71,7 @@ class GlobalsExtension extends \Twig_Extension
 			'DEMO'				=> '/demo/',
 
 			'downloads_path'	=> '/downloads/',
-			'downloads_path_32x' => 'https://bamboo.phpbb.com/browse/PHPBB3-RHEA/latestSuccessful/artifact/JOBPACKAGE/Release-Files',
+			'downloads_path_32x' => '/downloads/3.2/',
 			'downloads_path_31x' => '/downloads/3.1/',
 			'downloads_path_30x' => '/downloads/3.0/',
 
@@ -221,7 +221,8 @@ class GlobalsExtension extends \Twig_Extension
 			'DEV_QA_30X_BUGLIST'	=> '/bugs/phpbb3/qa.php',
 			'DEV_WIKI'			=> 'https://wiki.phpbb.com/',
 
-			'dev_github_phpbb_32x' => 'https://github.com/phpbb/phpbb/tree/master',
+			'dev_github_phpbb_master' => 'https://github.com/phpbb/phpbb/tree/master',
+			'dev_github_phpbb_32x' => 'https://github.com/phpbb/phpbb/tree/3.2.x',
 			'dev_github_phpbb_31x' => 'https://github.com/phpbb/phpbb/tree/3.1.x',
 			'dev_github_phpbb_30x' => 'https://github.com/phpbb/phpbb/tree/3.0.x',
 		);


### PR DESCRIPTION
Should not be merged until after phpBB 3.2.x is released.

To-do:
- [x] Add 3.3.x project name once decided
- [x] Finalize correct links to 3.2 and 3.1 downloads
- [x] Finalize planned dates for 3.1 EOM, EOL, and 3.2 and 3.3 dates
