### PR TITLE
Fix countdown timer

### DIFF
--- a/app/Resources/views/base/base.html.twig
+++ b/app/Resources/views/base/base.html.twig
@@ -362,7 +362,7 @@
 		var utc = new Date('Sat Jan 07 2017 17:00:00 GMT+0000 (UTC)').getTime();
 
 		$timerBox.countdown(utc).on('update.countdown', function(event) {
-			if (event.offset.days > 0) {
+			if (event.offset.totalDays > 0) {
 				number = event.strftime('%D');
 				unit = 'days left';
 			} else if (event.offset.hours > 0) {
@@ -375,7 +375,6 @@
 				number = event.strftime('%S');
 				unit = 'seconds';
 			}
-			unit = 'days left';
 			$timerBig.html(number);
 			$timerSmall.html(unit);
 		}).on('finish.countdown', function() {


### PR DESCRIPTION
The reason it was failing is because right now there are: 3 weeks and **0 days** remaining. 😜

This fix will change it to 21 days which is technically correct (because it's 21 full days and 18 hours) but it may look confusing.