### PR TITLE
Cleanup of Support landing page

### DIFF
--- a/src/AppBundle/Resources/views/Support/home.html.twig
+++ b/src/AppBundle/Resources/views/Support/home.html.twig
@@ -26,9 +26,9 @@
 	</div>
 	<div class="column2">
 		<h3><a href="{{ SUPPORT_FORUMS }}">Support Forums</a></h3>
-		<p>Have a question? We'd love to help! Post your own question in our support forums and our Support Team will assist.</p>
+		<p>Have a question? We'd love to help! Post your own question in our support forums and our Support Team will provide assistance.</p>
 		<h3><a href="{{ SUPPORT_DOCS_KB }}">Knowledge Base</a></h3>
-		<p>Our Knowledge Base contains articles from all different kind of areas, including loads of useful tutorials.</p>
+		<p>Our Knowledge Base contains useful articles and tutorials covering many different subjects and support areas.</p>
 		<h3><a href="{{ SUPPORT_INTL }}">International Support</a></h3>
 		<p>Because phpBB is multilingual, a number of 3rd party sites have appeared to support those whose first language is not English.</p>
 	</div>

--- a/src/AppBundle/Resources/views/Support/home.html.twig
+++ b/src/AppBundle/Resources/views/Support/home.html.twig
@@ -19,22 +19,18 @@
 	<div class="column1">
 		<h3><a href="{{ SUPPORT_DOCS }}">Documentation</a></h3>
 		<p>The installation guide and full documentation to the forum (board) system. This should be your first stop in finding solutions.</p>
-		<h3><a href="{{ SUPPORT_TUTORIALS_3_0 }}">Flash Tutorials</a></h3>
-		<p>A picture is worth a thousand words. We've taken that idea and created flash tutorials showing common tasks you will be performing while using phpBB.</p>
  		<h3><a href="{{ SUPPORT_IRC }}">IRC Support</a></h3>
 		<p>A support channel is registered on the freenode.net IRC network. Note that this channel is for phpBB discussion or support only.</p>
 		<h3><a href="{{ SUPPORT_SRT }}">Support Request Template</a></h3>
 		<p>We've created a tool to help you provide us with the information we need to help you in the Support Forum. Please run this tool whenever you create a new support topic.</p>
 	</div>
 	<div class="column2">
-		<h3><a href="{{ SUPPORT_DOCS_KB }}">Knowledge Base</a></h3>
-		<p>The knowledge base contains team and user submitted articles, covering a number of support areas. We encourage you to add your own content.</p>
 		<h3><a href="{{ SUPPORT_FORUMS }}">Support Forums</a></h3>
-		<p>If you cannot find an answer in the resources, please post in an appropriate forum. Before posting a question, please make use of the search facility.</p>
+		<p>Have a question? We'd love to help! Post your own question in our support forums and our Support Team will assist.</p>
+		<h3><a href="{{ SUPPORT_DOCS_KB }}">Knowledge Base</a></h3>
+		<p>Our Knowledge Base contains articles from all different kind of areas, including loads of useful tutorials.</p>
 		<h3><a href="{{ SUPPORT_INTL }}">International Support</a></h3>
 		<p>Because phpBB is multilingual, a number of 3rd party sites have appeared to support those whose first language is not English.</p>
-		<h3><a href="{{ SUPPORT_STK }}">Support Toolkit</a></h3>
-		<p>A toolkit developed and maintained by the Support Team, that can be used recover various parts of a corrupted phpBB 3.0.x installation or to solve commonly encountered problems with the software.</p>
 	</div>
 </div>
 <div id="extras">


### PR DESCRIPTION
Deleted Flash Tutorials and Support Toolkit from the Support landing page. All of these are from the 3.0 days and not useful any more today. 

Also put the link to the Support Forums higher up on the page. People clicking Support are most likely to want to find the support forums, and we should make it as easy (or user-friendly) as possible for them. 