### PR TITLE
Removing phpBB Mascot link until we get new Berties

### DIFF
--- a/src/AppBundle/Resources/views/Global/index.html.twig
+++ b/src/AppBundle/Resources/views/Global/index.html.twig
@@ -79,10 +79,6 @@
 		</ul>
 		</div>
 	</div>
-	<!-- <dl class="extra-box shop light-blue">
-		<dt><a href="{{ shop_path }}">phpBB Mascot</a></dt>
-		<dd><a href="{{ shop_path }}">Show your support for the phpBB project by getting a <span style="text-decoration: underline;">Bertie 3.0</span>!</a></dd>
-	</dl> -->
 </div>
 </div>
 {% endblock %}

--- a/src/AppBundle/Resources/views/Global/index.html.twig
+++ b/src/AppBundle/Resources/views/Global/index.html.twig
@@ -79,10 +79,10 @@
 		</ul>
 		</div>
 	</div>
-	<dl class="extra-box shop light-blue">
+	<!-- <dl class="extra-box shop light-blue">
 		<dt><a href="{{ shop_path }}">phpBB Mascot</a></dt>
 		<dd><a href="{{ shop_path }}">Show your support for the phpBB project by getting a <span style="text-decoration: underline;">Bertie 3.0</span>!</a></dd>
-	</dl>
+	</dl> -->
 </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
As Berties have been out of stock for awhile, it's probably wise not to advertise for them on our homepage until (if?) we get new ones.