### PR TITLE
Remove Modifications links from navbar

### DIFF
--- a/app/Resources/views/base/base.html.twig
+++ b/app/Resources/views/base/base.html.twig
@@ -149,7 +149,7 @@
 			<li class="nav-button but-customise">
 				<a href="{{ U_CUSTOMISE }}">Customise</a>
 
-				<div class="sub-menu wide-menu">
+				<div class="sub-menu">
 					<ul class="wide-list">
 						<li>
 							<h4><a href="{{ U_CDB_SUB }}">Customisation Database</a></h4>
@@ -157,7 +157,7 @@
 							<p><a href="{{ U_CDB_SUB }}">Our customisation database contains just about everything you might need to customise your phpBB board to your liking. In it you will find Extensions (for phpBB 3.1/3.2), Styles, Language Packs, BBCodes, as well as various tools.</a></p>
 						</li>
 					</ul>
-					<ul class="narrow-list">
+					<ul>
 						<li>
 							<h4><a href="{{ U_EXT_SUB }}">Extensions <small>(3.2.x)</small></a></h4>
 							<p><a href="{{ U_EXT_SUB }}">Guides on how to use them and how to create your own.</a></p>
@@ -167,17 +167,7 @@
 							<p><a href="{{ U_EXT_DB_SUB }}">Download or submit extensions to our extensions database.</a></p>
 						</li>
 					</ul>
-					<ul class="narrow-list">
-						<li>
-							<h4><a href="{{ U_MODS_SUB }}">Modifications <small>(3.0.x)</small></a></h4>
-							<p><a href="{{ U_MODS_SUB }}">Guides on how to use them and how to create your own.</a></p>
-						</li>
-						<li class="last">
-							<h4><a href="{{ U_MODS_DB_SUB }}">Modifications DB</a></h4>
-							<p><a href="{{ U_MODS_DB_SUB }}">Download or submit modifications to our MODs database.</a></p>
-						</li>
-					</ul>
-					<ul class="narrow-list">
+					<ul>
 						<li>
 							<h4><a href="{{ U_STYLES_SUB }}">Styles</a></h4>
 							<p><a href="{{ U_STYLES_SUB }}">Guides on how to use them and to create your own styles.</a></p>

--- a/src/AppBundle/Twig/GlobalsExtension.php
+++ b/src/AppBundle/Twig/GlobalsExtension.php
@@ -593,8 +593,6 @@ class GlobalsExtension extends \Twig_Extension implements \Twig_Extension_Global
 			'U_CDB_SUB'							=> '/customise/db/',
 			'U_EXT_SUB'							=> '/extensions/',
 			'U_EXT_DB_SUB'						=> '/customise/db/extensions-36',
-			'U_MODS_SUB'						=> '/mods/',
-			'U_MODS_DB_SUB'						=> '/customise/db/modifications-1',
 			'U_STYLES_SUB'						=> '/styles/',
 			'U_STYLES_DEMO_SUB'					=> '/styles/demo/3.0/',
 


### PR DESCRIPTION
Since it's not even displayed in CDB categories and 3.0 is way past EOL, it should be removed from the main navbar as well.